### PR TITLE
Tracker compatible with Python 3.9

### DIFF
--- a/tracker/tracker.py
+++ b/tracker/tracker.py
@@ -313,7 +313,7 @@ see more info: https://github.com/dmlc/rabit/blob/master/doc/guide.md
         self.thread.start()
 
     def join(self):
-        while self.thread.isAlive():
+        while self.thread.is_alive():
             self.thread.join(100)
 
 class PSTracker:
@@ -363,7 +363,7 @@ class PSTracker:
 
     def join(self):
         if self.cmd is not None:
-            while self.thread.isAlive():
+            while self.thread.is_alive():
                 self.thread.join(100)
 
     def slave_envs(self):


### PR DESCRIPTION
Update deprecated `Thread.isAlive` to `Thread.is_alive` to be compatible with Python 3.9

REF: https://github.com/python/cpython/pull/11454